### PR TITLE
Add argument to specify additional archs to consider

### DIFF
--- a/bin/rpm-s3
+++ b/bin/rpm-s3
@@ -279,7 +279,7 @@ if __name__ == '__main__':
     parser.add_option('-d', '--delete', action='store_true', default=False)
     parser.add_option('-r', '--region')
     parser.add_option('-c', '--host', default='s3-eu-central-1.amazonaws.com')
-    parser.add_option('-a', '--archs', type='string', action='callback', callback=get_comma_separated_args)
+    parser.add_option('-a', '--archs', type='string', default='', action='callback', callback=get_comma_separated_args)
     options, args = parser.parse_args()
     if options.region is not None and options.host != 's3-eu-central-1.amazonaws.com':
         parser.error('region and host are mutually exclusive')

--- a/bin/rpm-s3
+++ b/bin/rpm-s3
@@ -184,6 +184,10 @@ def update_repodata(repopath, rpmfiles, options):
     repo = yumbase.add_enable_repo('s3')
     repo._grab = s3grabber
 
+    # Add all needed architectures to the repo list
+    for arch in options.archs:
+        yumbase.arch.archlist.append(arch)
+
     setup_repository(repo, repopath)
 
     # Ensure that missing base path doesn't cause trouble
@@ -227,6 +231,7 @@ def update_repodata(repopath, rpmfiles, options):
         if not options.delete:
             new_packages.append(newpkg)
 
+    logging.info("Previous package list: %s", list(yumbase.pkgSack))
     mdconf.pkglist = list(yumbase.pkgSack) + new_packages
 
     # Write out new metadata to tmpdir
@@ -260,6 +265,8 @@ def main(options, args):
 
     update_repodata(options.repopath, args, options)
 
+def get_comma_separated_args(option, opt, value, parser):
+    setattr(parser.values, option.dest, value.split(','))
 
 if __name__ == '__main__':
     parser = optparse.OptionParser()
@@ -272,6 +279,7 @@ if __name__ == '__main__':
     parser.add_option('-d', '--delete', action='store_true', default=False)
     parser.add_option('-r', '--region')
     parser.add_option('-c', '--host', default='s3-eu-central-1.amazonaws.com')
+    parser.add_option('-a', '--archs', type='string', action='callback', callback=get_comma_separated_args)
     options, args = parser.parse_args()
     if options.region is not None and options.host != 's3-eu-central-1.amazonaws.com':
         parser.error('region and host are mutually exclusive')

--- a/bin/rpm-s3
+++ b/bin/rpm-s3
@@ -284,7 +284,7 @@ if __name__ == '__main__':
     parser.add_option('-d', '--delete', action='store_true', default=False)
     parser.add_option('-r', '--region')
     parser.add_option('-c', '--host', default='s3-eu-central-1.amazonaws.com')
-    parser.add_option('-a', '--archs', type='string', default='', action='callback', callback=get_comma_separated_args)
+    parser.add_option('-a', '--archs', type='string', default=[], action='callback', callback=get_comma_separated_args)
     options, args = parser.parse_args()
     if options.region is not None and options.host != 's3-eu-central-1.amazonaws.com':
         parser.error('region and host are mutually exclusive')

--- a/bin/rpm-s3
+++ b/bin/rpm-s3
@@ -236,7 +236,7 @@ def update_repodata(repopath, rpmfiles, options):
 
     mdconf.pkglist = list(yumbase.pkgSack) + new_packages
 
-    # Log old package list
+    # Log new package list
     logging.info("New package list: %s", mdconf.pkglist)
 
     # Write out new metadata to tmpdir

--- a/bin/rpm-s3
+++ b/bin/rpm-s3
@@ -200,6 +200,9 @@ def update_repodata(repopath, rpmfiles, options):
     mdgen = createrepo.MetaDataGenerator(mdconf, LoggerCallback())
     mdgen.tempdir = tmpdir
 
+    # Log old package list
+    logging.info("Previous package list: %s", list(yumbase.pkgSack))
+
     # Combine existing package sack with new rpm file list
     new_packages = []
     for rpmfile in rpmfiles:
@@ -231,8 +234,10 @@ def update_repodata(repopath, rpmfiles, options):
         if not options.delete:
             new_packages.append(newpkg)
 
-    logging.info("Previous package list: %s", list(yumbase.pkgSack))
     mdconf.pkglist = list(yumbase.pkgSack) + new_packages
+
+    # Log old package list
+    logging.info("New package list: %s", mdconf.pkglist)
 
     # Write out new metadata to tmpdir
     mdgen.doPkgMetadata()


### PR DESCRIPTION
### What does this PR do?

The `YumBase` object's list of considered archs only includes archs that are compatible with the host arch. For instance, on an x86_64 host, ARM architectures aren't on this list. The consequence of this is that packages for archs that are not in this list are not considered.

In particular, this means it's currently not possible to manage an ARM repo from an x86_64 host, as the existing list of ARM packages would be ignored.

Add an `--archs` option that allows supplying a list of archs that should be considered for the repo operations.