### PR TITLE
Improve repo signing capabilities

### DIFF
--- a/bin/rpm-s3
+++ b/bin/rpm-s3
@@ -147,9 +147,11 @@ def sign(rpmfile):
         logging.error("Unable to sign package: %s", e)
         exit(1)
 
-def sign_metadata(repomdfile):
-    """Requires a proper ~/.rpmmacros file. See <http://fedoranews.org/tchung/gpg/>"""
-    cmd = ["gpg", "--detach-sign", "--armor", repomdfile]
+def sign_metadata(repomdfile, key):
+    cmd = ["gpg", "--pinentry-mode", "loopback", "--yes", "--batch", "--passphrase-fd", "0", "--detach-sign", "--armor"]
+    if key:
+        cmd.extend(["-u", key])
+    cmd.append(repomdfile)
     logging.info(cmd)
     try:
         subprocess.check_call(cmd)
@@ -210,7 +212,7 @@ def update_repodata(repopath, rpmfiles, options):
         rpmfile = os.path.realpath(rpmfile)
         logging.info("rpmfile: %s", rpmfile)
 
-        if options.sign:
+        if options.sign and not options.no_rpm_resign:
             sign(rpmfile)
 
         mdgen._grabber = filegrabber
@@ -254,7 +256,7 @@ def update_repodata(repopath, rpmfiles, options):
 
     # Generate repodata/repomd.xml.asc
     if options.sign:
-        sign_metadata(os.path.join(tmpdir, 'repodata', 'repomd.xml'))
+        sign_metadata(os.path.join(tmpdir, 'repodata', 'repomd.xml'), options.metadata_signing_key)
 
     # Replace metadata on s3
     s3grabber.syncdir(os.path.join(tmpdir, 'repodata'), 'repodata')
@@ -281,6 +283,8 @@ if __name__ == '__main__':
     parser.add_option('-v', '--verbose', action='count', default=0)
     parser.add_option('--visibility', default='private')
     parser.add_option('-s', '--sign', action='count', default=0)
+    parser.add_option('-n', '--no-rpm-resign', action='store_true', default=False)
+    parser.add_option('-k', '--metadata-signing-key', default='')
     parser.add_option('-l', '--logfile')
     parser.add_option('-d', '--delete', action='store_true', default=False)
     parser.add_option('-r', '--region')

--- a/bin/rpm-s3
+++ b/bin/rpm-s3
@@ -212,7 +212,7 @@ def update_repodata(repopath, rpmfiles, options):
         rpmfile = os.path.realpath(rpmfile)
         logging.info("rpmfile: %s", rpmfile)
 
-        if options.sign and not options.no_rpm_resign:
+        if options.sign and options.rpm_resign:
             sign(rpmfile)
 
         mdgen._grabber = filegrabber
@@ -283,7 +283,7 @@ if __name__ == '__main__':
     parser.add_option('-v', '--verbose', action='count', default=0)
     parser.add_option('--visibility', default='private')
     parser.add_option('-s', '--sign', action='count', default=0)
-    parser.add_option('-n', '--no-rpm-resign', action='store_true', default=False)
+    parser.add_option('-n', '--rpm-resign', action='store_true', default=False)
     parser.add_option('-k', '--metadata-signing-key', default='')
     parser.add_option('-l', '--logfile')
     parser.add_option('-d', '--delete', action='store_true', default=False)


### PR DESCRIPTION
* Allow skipping the RPM resigning step
* Allow choosing specific key to sign repodata with
* Fix the `sign_metadata` operation to properly read key passphrase from stdin of `rpm-s3`