### PR TITLE
Update rpm-s3

### DIFF
--- a/bin/rpm-s3
+++ b/bin/rpm-s3
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """CLI for serialising metadata updates on an s3-hosted yum repository.
 """
 import os


### PR DESCRIPTION
I [bumped Python](https://github.com/DataDog/datadog-agent-buildimages/pull/591) to 3.11 and [boom](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/515530559) because `python` is 3 by default there now