### PR TITLE
Remove vendored pexpect submodule

### DIFF
--- a/bin/rpm-s3
+++ b/bin/rpm-s3
@@ -13,11 +13,9 @@ import collections
 import yum
 import boto
 import subprocess
+import pexpect
 
 lib_root = os.path.dirname(os.path.dirname(__file__))
-
-sys.path.insert(1, os.path.join(lib_root, "vendor/pexpect"))
-import pexpect
 
 sys.path.insert(1, os.path.join(lib_root, "vendor/createrepo"))
 import createrepo


### PR DESCRIPTION
Vendoring this TTY management library is unnecessary as far as I understand